### PR TITLE
Add pre-vsce step

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
     "lint": "eslint src --ext ts",
     "test": "node ./out/test/runTest.js",
+    "prevsce": "mkdir -p dist/node_modules; rsync -av node_modules/onnxruntime-node dist/node_modules --exclude lib; rsync -av node_modules/onnxruntime-common dist/node_modules --exclude lib",
     "vsce": "vsce package"
   },
   "devDependencies": {


### PR DESCRIPTION
Add `npm` step copying the content of `onnxruntime-node` and `onnxruntime-common` to the `dist` folder.

Test the extension:
- run `npm ci`
- run `npm run vsce`
- in VS Code, use the "Install from VSIX" command in the command palette
- try executing the "Hello World" command, you should get a "Hello World from hello-world-ort-node!" message, and if you open the developer tools there should be a "data of result tensor" message:
![image](https://user-images.githubusercontent.com/51720070/226231607-513061f6-26e0-4589-8b4f-acc9f22b3f91.png)
